### PR TITLE
api calls

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -1,9 +1,0 @@
-const express = require("express");
-const fetch = require('node-fetch');
-const router = express.Router();
-// const tools = require('./github');
-
-// tools.fetchUsers();
-
-module.exports = router;
-

--- a/server/github.js
+++ b/server/github.js
@@ -1,9 +1,11 @@
 const fetch = require('node-fetch');
 const mongoose = require("mongoose");
 const Post = require("./models/Post");
+const { auth } = require('google-auth-library');
 require("dotenv").config();
 
 const mongoConnectionURL = process.env.MONGODB_SRV; 
+const authHeader = `Bearer ${process.env.GITHUB_TOKEN}`; 
 
 const connectToDB = async () => {
     mongoose
@@ -30,7 +32,11 @@ var repo = "httpie";
 async function fetchIssues(org, repo) {
     await connectToDB();
     try {
-        fetch(`https://api.github.com/repos/${org}/${repo}/${issues}`)
+        fetch(`https://api.github.com/repos/${org}/${repo}/${issues}`, {
+          headers: {
+            Authorization: authHeader
+          }
+        })
         .then(response => response.json())
         .then(data => {
             var issues = [];
@@ -67,6 +73,36 @@ async function fetchIssues(org, repo) {
         console.log(err);
     }
 }
+
+async function fetchSingleIssue(org, repo, issue) {
+    try {
+      const resp = await fetch(`https://api.github.com/repos/${org}/${repo}/${issues}/${issue}`, {
+        headers: {
+          Authorization: authHeader
+          }
+      });
+      const data = await resp.json();
+      const post = {
+        'creator': '',
+        'tags': [repo, org],
+        'title': data.title,
+        'type': 'github',
+        'timestamp': new Date(data.created_at),
+        'isPublic': true,
+        'content': {
+            'url': data.url,
+            'body': data.body,
+            'state': data.state,
+            'creator': data.user.login,
+            'allAssignees': data.assignees
+        }
+      };
+      return post;
+    } catch (err) {
+      console.log(err);
+    }
+}
+
 
 async function fetchPRs(org, repo) {
     await connectToDB();
@@ -107,6 +143,35 @@ async function fetchPRs(org, repo) {
     } catch(err) {
         console.log(err);
     }
+}
+
+async function fetchSinglePR(org, repo, pr) {
+  try {
+    const resp = await fetch(`https://api.github.com/repos/${org}/${repo}/${pullRequests}/${pr}`, {
+      headers: {
+        Authorization: authHeader
+        }
+    });
+    const data = await resp.json();
+    const post = {
+      'creator': '',
+      'tags': [repo, org],
+      'title': data.title,
+      'type': "github",
+      'timestamp': new Date(data.created_at),
+      'isPublic': true,
+      'content': {
+          'url': data.url,
+          'body': data.body,
+          'state': data.state,
+          'creator': data.user.login,
+          'allAssignees': data.assignees
+      }
+    }
+    return post;
+  } catch (err) {
+    console.log(err);
+  }
 }
 
 const query = `
@@ -219,4 +284,4 @@ if (module === require.main) {
   fetchUsers().catch(console.error);
 }
 
-module.exports = {fetchIssues, fetchPRs, fetchUsers};
+module.exports = {fetchIssues, fetchPRs, fetchUsers, fetchSingleIssue, fetchSinglePR};

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -16,7 +16,7 @@ const UserSchema = new Schema({
     },
     fullname: String, 
     discord: String,
-    pinnedPosts: { type: [ObjectId], default: [] },
+    pinnedPosts: { type: [String], default: [] },
 
 });
 

--- a/server/routes/posts.js
+++ b/server/routes/posts.js
@@ -1,0 +1,116 @@
+const express = require("express");
+const router = express.Router();
+const Post = require("../models/Post.js");
+const youtube = require("../youtube.js");
+const github = require("../github.js");
+const qs = require('querystring');
+//get all public posts for All/Explore page
+router.get('/', async (req, res, next) => {
+    console.log(req.body);
+
+    try {
+        const posts = await Post.find({isPublic: true}).exec();
+        res.status(200).send(posts);
+    } catch(err) {
+        console.log(err);
+        res.status(500).send(err);
+    }
+});
+
+//get post by id (pinnedPosts under User)
+router.get('/:id', async (req, res, next) => {
+    try {
+        const id = req.params.id;
+        const post = await Post.findById(id).exec();
+        res.status(200).send(post);
+    } catch(err) {
+        console.log(err);
+        res.status(500).send(err);
+    }
+});
+
+router.get('/contacts', async (req, res, next) => {
+    try {
+        const contacts = await Post.find({type: "contacts"}).exec();
+        res.status(200).send(contacts);
+    } catch (err) {
+        console.log(err);
+        res.status(500).send(err);
+    }
+})
+//create a new post, will need to get type from user
+router.post('/', async (req, res, next) => {
+    try {
+        if(req.body.url) {
+            const youtubeRegex = /^(https?\:\/\/)?(www\.youtube\.com|youtu\.?be)\/.+$/;
+            const githubRegex = /^(https?\:\/\/)?(www\.github\.com|github\.com)\/.+$/;
+            const url = req.body.url;
+            if(youtubeRegex.test(url)) {
+                let videoId;
+                const youtubeShareRegex = /youtu\.be/;
+                //matches youtu.be links
+                if(youtubeShareRegex.test(url)) {
+                    videoId = url.split("youtu.be/")[1];
+                }
+                //matches youtube.com links
+                else {
+                    const urlToParse = url.split("?")[1];
+                    const parsed = qs.parse(urlToParse);
+                    videoId = parsed.v;
+                }
+
+                const videoPost = await youtube.getVideoData(videoId);
+                videoPost.creator = req.body.creator;
+
+                res.status(200).send(videoPost);
+            }
+            else if (githubRegex.test(url)) {
+                const params = url.split("github.com/").slice(1);
+                const [org, repo, type, id] = params[0].split("/");
+                if(type == 'issues') {
+                    const issue = await github.fetchSingleIssue(org, repo, id);
+                    issue.creator = req.body.creator;
+
+                    res.status(200).send(issue);
+                }
+                else if (type == 'pull') {
+                    const pr = await github.fetchSinglePR(org, repo, id);
+                    pr.creator = req.body.creator;
+
+                    res.status(200).send(pr);
+                }
+            }
+        }
+        else if (req.body.title) {
+            const post = Post(req.body);
+            //bugged, exist check doesnt work right now
+            const exists = await Post.findOne(post, "-_id -timestamp").exec();
+            if (exists) {
+                res.sendStatus(409);
+            }
+            else {
+                const saved = await post.save();
+                res.status(200).send(saved._id);
+            }
+        }
+        
+    } catch (err) {
+        console.log(err);
+        res.status(500).send(err);
+    }
+});
+
+//update post based on id, update post with new data in body
+router.post('/:id/', async (req, res) => {
+    const newData = req.body;
+    const id = req.params.id;
+    try {
+        const updated = await Post.findByIdAndUpdate(id, newData).exec();
+        res.status(200).send(updated);
+    } catch (err) {
+        console.log(err);
+        res.status(500).send(err);
+    }
+});
+
+module.exports = router;

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -1,0 +1,45 @@
+const express = require("express");
+const router = express.Router();
+const User = require("../models/User.js");
+
+router.get('/:username', async (req, res, next) => {
+    const username = req.params.username;
+    try {
+        const user = await User.findOne({username: username}).exec();
+        res.status(200).send(user);
+    } catch (err) {
+        console.log(err);
+        res.status(500).send(err);
+    }
+});
+
+//update pinned posts with new pinned posts array
+router.post('/:username/pins', async (req, res, next) => {
+    const username = req.params.username;
+    const newPins = req.body;
+
+    try {
+        const user = await User.findOneAndUpdate({username: username}, {"pinnedPosts": newPins}).exec();
+        res.status(200).send(user);
+    } catch (err) {
+        console.log(err);
+        res.status(500).send(err);
+    }
+});
+
+//update user object with new data from body
+//key: value, eg {avatarUrl: newAvatarUrl}
+router.post('/:username', async (req, res, next) => {
+    const username = req.params.username;
+    const newData = req.body;
+    try {
+        const user = await User.findOneAndUpdate({username: username}, newData).exec();
+        res.status(200).send(user);
+    } catch(err) {
+        console.log(err);
+        res.status(500).send(err);
+    }
+});
+
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -4,6 +4,9 @@ const bodyParser = require("body-parser");
 const FormData = require("form-data");
 const fetch = require("node-fetch");
 const path = require("path");
+const postRouter = require("./routes/posts.js");
+const userRouter = require("./routes/user.js");
+const api = require("./api.js");
 require("dotenv").config();
 
 // connect to database
@@ -15,6 +18,7 @@ mongoose
     useUnifiedTopology: true,
     useCreateIndex: true,
     dbName: "Dashboard",
+    useFindAndModify: false,
   })
   .then(() => console.log("Connected to MongoDB"))
   .catch((err) => console.log(`${err}: Failed to connect to MongoDB`));
@@ -22,12 +26,13 @@ mongoose
 // default all api endpoints to the defined routes in `api.js`
 const app = express();
 app.use(express.json());
-app.use("/api", require("./api.js"));
 
 app.use(bodyParser.json());
 app.use(bodyParser.json({ type: "text/*" }));
-app.use(bodyParser.urlencoded({ extended: false }));
-
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use("/api", api);
+app.use("/api/posts", postRouter);
+app.use("/api/users", userRouter);
 app.use((req, res, next) => {
   res.header("Access-Control-Allow-Origin", "*");
   next();

--- a/server/server.js
+++ b/server/server.js
@@ -6,7 +6,6 @@ const fetch = require("node-fetch");
 const path = require("path");
 const postRouter = require("./routes/posts.js");
 const userRouter = require("./routes/user.js");
-const api = require("./api.js");
 require("dotenv").config();
 
 // connect to database
@@ -30,7 +29,6 @@ app.use(express.json());
 app.use(bodyParser.json());
 app.use(bodyParser.json({ type: "text/*" }));
 app.use(bodyParser.urlencoded({ extended: true }));
-app.use("/api", api);
 app.use("/api/posts", postRouter);
 app.use("/api/users", userRouter);
 app.use((req, res, next) => {

--- a/server/youtube.js
+++ b/server/youtube.js
@@ -4,7 +4,7 @@ const Post = require('./models/Post');
 require('dotenv').config();
 
 const mongoConnectionURL = process.env.MONGODB_SRV; 
-
+const YOUTUBE_API_KEY = process.env.YOUTUBE_API_KEY;
 const connectToDB = async () => {
     mongoose
     .connect(mongoConnectionURL, {
@@ -34,7 +34,7 @@ const getUploadedVideos = async (channelId, filterBy = "MLH Fellowship", tags = 
     // get the MLH channel
     const youtube = google.youtube("v3");
     const channel = await youtube.channels.list({
-        auth: process.env.YOUTUBE_API_KEY,
+        auth: YOUTUBE_API_KEY,
         part: "contentDetails,status",
         id: channelId,
     });
@@ -47,7 +47,7 @@ const getUploadedVideos = async (channelId, filterBy = "MLH Fellowship", tags = 
     const playlistId = channel.data.items[0].contentDetails.relatedPlaylists.uploads;
     const playlist = await youtube.playlistItems.list({
         playlistId,
-        auth: process.env.YOUTUBE_API_KEY,
+        auth: YOUTUBE_API_KEY,
         part: "snippet,status,contentDetails",
         maxResults: 50,
     });
@@ -77,6 +77,30 @@ const getUploadedVideos = async (channelId, filterBy = "MLH Fellowship", tags = 
     return videos
 }
 
+const getVideoData = async (videoId) => {
+    const youtube = google.youtube("v3");
+    const req = await youtube.videos.list({
+        id: videoId,
+        auth: YOUTUBE_API_KEY,
+        part: "snippet"
+    });
+  
+    const video = await req.data.items[0];
+    const post = {
+        tags: video.snippet.tags,
+        creator: "",
+        type: "youtube",
+        title: video.snippet.title,
+        content: {
+            id: video.id,
+            description: video.snippet.description,
+            thumbnails: video.snippet.thumbnails.standard
+        },
+        timestamp: new Date(video.snippet.publishedAt),
+        isPublic: true
+    };
+    return post;
+}
 /**
  * Adds list of videos to DB, given that the videos are already formatted
  * to match the Post schema.
@@ -116,5 +140,5 @@ const prepopulateVideos = async () => {
 if (module === require.main) {
     prepopulateVideos().catch(console.error);
 }
-module.exports = { getUploadedVideos, addVideosToDb };
+module.exports = { getUploadedVideos, addVideosToDb, getVideoData };
 


### PR DESCRIPTION
for #17 

Tested each route with postman and things seem to be good. Only caveat is that the response after an edit operation is the old document and not the one with changes applied (at least on postman) so to get the updated document after an edit, you need to `GET` the document again.

some comments:

- Changed the `pinnedPosts` type to `String` for id, I was getting an error about `ObjectID` not being defined (which I think is because it should be `mongoose.Types.ObjectID`), but I think `String` is easier to work with and I'm not sure if there's an added benefit to using `ObjectID` (if there is let me know and I'll change things to work with it!)
- There might be some overlap with the `user` API calls between Rodrigo's PR, will have to discuss and see how we want to structure the endpoint methods
- Created a `routes/` folder for storing all the different router files, so maybe we can get rid of `api.js` if it's not being used? I think putting all the APIs inside `api.js` will make it too big + conflicts might arise when working on APIs so maybe we can get rid of it.
- For posts I limited it to just changing the tags and content, maybe we can also add methods for editing the title/type/publicity? Would be very easy to do.

some more comments:

- should we add implementations for post limiting, sorting (by timestamp), and randomizing?
- do we need some way of validating unique posts, or should we trust the user to not submit the exact same thing multiple times?
- should we clean everything from the database and readd things just to be sure we don't have extras/test documents in there?

