### PR TITLE
Add more tags for github fetched contacts

### DIFF
--- a/server/github.js
+++ b/server/github.js
@@ -241,7 +241,7 @@ async function fetchUsers() {
       
       const members = team.members.nodes;
       members.forEach(user => {
-          const tags = ['contact', 'Summer-2020', team.name];
+          const tags = ['Summer-2020', team.name];
           if (team.name.startsWith('Pod')) {
             tags.push('Fellow');
           }

--- a/server/github.js
+++ b/server/github.js
@@ -240,6 +240,7 @@ async function fetchUsers() {
       if (['TTP Fellows (Summer 2020)', 'CTF', 'MLH Fellows (Summer 2020)'].includes(team.name)) return;
       
       const members = team.members.nodes;
+
       members.forEach(user => {
           var singleUser = {
             'creator': 'server',

--- a/server/github.js
+++ b/server/github.js
@@ -238,12 +238,12 @@ async function fetchUsers() {
       team = obj.node;
 
       if (['TTP Fellows (Summer 2020)', 'CTF', 'MLH Fellows (Summer 2020)'].includes(team.name)) return;
-
+      
       const members = team.members.nodes;
       members.forEach(user => {
           var singleUser = {
             'creator': 'server',
-            'tags': ['contact'],
+            'tags': ['contact', team.name],
             'title': (user.name !== null) ? user.name : user.login.toLowerCase(),
             'type': 'contacts',
             'isPublic': true,

--- a/server/github.js
+++ b/server/github.js
@@ -240,11 +240,14 @@ async function fetchUsers() {
       if (['TTP Fellows (Summer 2020)', 'CTF', 'MLH Fellows (Summer 2020)'].includes(team.name)) return;
       
       const members = team.members.nodes;
-
       members.forEach(user => {
+          const tags = ['contact', 'Summer-2020', team.name];
+          if (team.name.startsWith('Pod')) {
+            tags.push('Fellow');
+          }
           var singleUser = {
             'creator': 'server',
-            'tags': ['contact', team.name],
+            'tags': tags,
             'title': (user.name !== null) ? user.name : user.login.toLowerCase(),
             'type': 'contacts',
             'isPublic': true,


### PR DESCRIPTION
Fixes #35 

Tags are now: `['MLH Staf/Pod number/Mentors', 'Summer 2020']` and if they're a fellow, theyll have a `#Fellow` too.